### PR TITLE
Правка коллективной выдачи

### DIFF
--- a/Workwear/Domain/Company/EmployeeCardItem.cs
+++ b/Workwear/Domain/Company/EmployeeCardItem.cs
@@ -192,10 +192,12 @@ namespace workwear.Domain.Company
 
 		/// <summary>
 		/// Необходимое к выдачи количество.
-		/// Внимание! Не корректно считает сложные ситуации, с неполной выдачей.
 		/// </summary>
 		public virtual int CalculateRequiredIssue(BaseParameters parameters)
 		{
+			if (NextIssue.HasValue && LastIssue.HasValue && LastIssue >= NextIssue) //Костыль для ловли неполной выдачи (т.к. при неполной выдачи в NextIssue проставляется текущая дата)
+				return ActiveNormItem.Amount - Amount;
+
 			if(NextIssue.HasValue && NextIssue.Value.AddDays(-parameters.ColDayAheadOfShedule) <= DateTime.Today)
 				return ActiveNormItem.Amount;
 			else 

--- a/Workwear/Domain/Company/EmployeeCardItem.cs
+++ b/Workwear/Domain/Company/EmployeeCardItem.cs
@@ -192,12 +192,10 @@ namespace workwear.Domain.Company
 
 		/// <summary>
 		/// Необходимое к выдачи количество.
+		/// Внимание! Не корректно считает сложные ситуации, с неполной выдачей.
 		/// </summary>
 		public virtual int CalculateRequiredIssue(BaseParameters parameters)
 		{
-			if (NextIssue.HasValue && LastIssue.HasValue && LastIssue >= NextIssue) //Костыль для ловли неполной выдачи (т.к. при неполной выдачи в NextIssue проставляется текущая дата)
-				return ActiveNormItem.Amount - Amount;
-
 			if(NextIssue.HasValue && NextIssue.Value.AddDays(-parameters.ColDayAheadOfShedule) <= DateTime.Today)
 				return ActiveNormItem.Amount;
 			else 

--- a/Workwear/Domain/Stock/CollectiveExpense.cs
+++ b/Workwear/Domain/Stock/CollectiveExpense.cs
@@ -121,7 +121,7 @@ namespace workwear.Domain.Stock
 			}
 		}
 
-		public virtual void AddItem(EmployeeCardItem employeeCardItem, StockPosition position = null, int amount = 0) //Добавляем строку когда есть на складе
+		public virtual CollectiveExpenseItem AddItem(EmployeeCardItem employeeCardItem, StockPosition position = null, int amount = 0) 
 		{
 			var newItem = new CollectiveExpenseItem() {
 				Document = this,
@@ -137,15 +137,16 @@ namespace workwear.Domain.Stock
 				}
 
 			ObservableItems.Add(newItem);
+			return newItem;
 		}
 
-		public virtual void AddItem(EmployeeCardItem employeeCardItem, BaseParameters baseParameters)
+		public virtual CollectiveExpenseItem AddItem(EmployeeCardItem employeeCardItem, BaseParameters baseParameters)
 		{
 			if(employeeCardItem == null)
 				throw new ArgumentNullException(nameof(employeeCardItem));
 
 			if(Items.Any(x => employeeCardItem.IsSame(x.EmployeeCardItem)))
-				return;
+				return null;
 
 			int NeedPositionAmount = employeeCardItem.CalculateRequiredIssue(baseParameters); //Количество которое нужно выдать
 			if(employeeCardItem.BestChoiceInStock.Any()) {
@@ -155,20 +156,17 @@ namespace workwear.Domain.Stock
 						if(item.Nomenclature == position.Nomenclature && item.Size == position.Size) 
 							ExpancePositionAmount -= item.Amount; 
 
-					if(ExpancePositionAmount >= NeedPositionAmount && position.WearPercent == 0) {
-							AddItem(employeeCardItem, position.StockPosition, NeedPositionAmount);
-							NeedPositionAmount = 0; 
-							break;
-					}
+					if(ExpancePositionAmount >= NeedPositionAmount && position.WearPercent == 0)
+						return AddItem(employeeCardItem, position.StockPosition, NeedPositionAmount);
 				}
 			}
-			if(NeedPositionAmount != 0)
-				AddItem(employeeCardItem);
+			return AddItem(employeeCardItem);
 		}
 
 		public virtual void RemoveItem(CollectiveExpenseItem item)
 		{
 			ObservableItems.Remove (item);
+			Items.Remove(item);
 		}
 
 		public virtual void CleanupItems()

--- a/Workwear/Domain/Stock/CollectiveExpense.cs
+++ b/Workwear/Domain/Stock/CollectiveExpense.cs
@@ -153,7 +153,7 @@ namespace workwear.Domain.Stock
 				foreach(var position in employeeCardItem.BestChoiceInStock) {
 					int ExpancePositionAmount = position.Amount;  //Есть на складе
 					foreach(var item in Items) //Считаем сколько осталось на складе c учётом этого документа
-						if(item.Nomenclature == position.Nomenclature && item.Size == position.Size) 
+						if(item.Nomenclature == position.Nomenclature && item.Size == position.Size && item.WearGrowth == position.Growth) 
 							ExpancePositionAmount -= item.Amount; 
 
 					if(ExpancePositionAmount >= NeedPositionAmount && position.WearPercent == 0)

--- a/Workwear/Domain/Stock/CollectiveExpense.cs
+++ b/Workwear/Domain/Stock/CollectiveExpense.cs
@@ -15,7 +15,7 @@ using workwear.Tools;
 
 namespace workwear.Domain.Stock
 {
-	[Appellative (Gender = GrammaticalGender.Masculine,
+	[Appellative (Gender = GrammaticalGender.Feminine,
 		NominativePlural = "коллективные выдачи",
 		Nominative = "коллективная выдача")]
 	public class CollectiveExpense : StockDocument, IValidatableObject

--- a/WorkwearTest/Integration/Operations/EmployeeIssueRepositoryTest.cs
+++ b/WorkwearTest/Integration/Operations/EmployeeIssueRepositoryTest.cs
@@ -213,19 +213,38 @@ namespace WorkwearTest.Integration.Operations
 				var warehouse = new Warehouse();
 				uow.Save(warehouse);
 
+				var protectionTools = new ProtectionTools();
+				protectionTools.Name = "Тестовая курточка";
+				uow.Save(protectionTools);
+
 				var nomenclatureType = new ItemsType();
 				nomenclatureType.Name = "Тестовый тип номенклатуры";
 				uow.Save(nomenclatureType);
 
 				var nomenclature = new Nomenclature();
 				nomenclature.Type = nomenclatureType;
+				nomenclature.ProtectionTools.Add(protectionTools);
 				uow.Save(nomenclature);
 
+				var norm = new Norm();
+				norm.AddItem(protectionTools);
+				uow.Save(norm);
+
 				var employee = new EmployeeCard();
+				employee.AddUsedNorm(norm);
 				uow.Save(employee);
-				
+
 				var employee2 = new EmployeeCard();
+				employee2.AddUsedNorm(norm);
 				uow.Save(employee2);
+
+				var employeeCardItem = employee.WorkwearItems.FirstOrDefault();
+				employeeCardItem.EmployeeCard = employee;
+				uow.Save(employeeCardItem);
+
+				var employeeCardItem2 = employee2.WorkwearItems.FirstOrDefault();
+				employeeCardItem2.EmployeeCard = employee2;
+				uow.Save(employeeCardItem2);
 
 				var expense = new CollectiveExpense() {
 					Date = new DateTime(2021, 9, 10),
@@ -233,8 +252,8 @@ namespace WorkwearTest.Integration.Operations
 				};
 
 				var stockPosition = new StockPosition(nomenclature, null, null, 0);
-				var item = expense.AddItem(employee, stockPosition, 1);
-				var item2 = expense.AddItem(employee2, stockPosition, 10);
+				var item = expense.AddItem(employee.WorkwearItems.FirstOrDefault(), stockPosition, 1);
+				var item2 = expense.AddItem(employee2.WorkwearItems.FirstOrDefault(), stockPosition, 10);
 
 				expense.UpdateOperations(uow, baseParameters, interactive);
 				uow.Save(expense);

--- a/WorkwearTest/Integration/Operations/EmployeeIssueRepositoryTest.cs
+++ b/WorkwearTest/Integration/Operations/EmployeeIssueRepositoryTest.cs
@@ -238,14 +238,6 @@ namespace WorkwearTest.Integration.Operations
 				employee2.AddUsedNorm(norm);
 				uow.Save(employee2);
 
-				var employeeCardItem = employee.WorkwearItems.FirstOrDefault();
-				employeeCardItem.EmployeeCard = employee;
-				uow.Save(employeeCardItem);
-
-				var employeeCardItem2 = employee2.WorkwearItems.FirstOrDefault();
-				employeeCardItem2.EmployeeCard = employee2;
-				uow.Save(employeeCardItem2);
-
 				var expense = new CollectiveExpense() {
 					Date = new DateTime(2021, 9, 10),
 					Warehouse = warehouse,


### PR DESCRIPTION
Внёс правки. Сейчас При выборе сотрудника, выбирается с учётом ранее добавленных строк, сначала довыдаётся одна номенклатура, потом другая и может быть ситуация, когда одному сотруднику выдаётся 2 разные номенклатуры. Я так понял, что сейчас в программе это плохой вариант, т.к. как минимум расчёт довыдачи ломается, когда больше 2 строк с одинаковой нормой. 

Я считаю, что здесь было бы неплохо реализовать выделение цветом, чтобы программа отмечала, сотрудников которым не смогла выдать полностью.

-Можно сделать, чтобы в коллективной выдачи, сначала программа искала нужную номенклатуру в достаточном количестве и если не найдёт выдавала, как сейчас (уменьшит количество ошибок)
-Можно сделать, чтобы искала и выдавала полностью, если не найдёт, то частично, но одной номенклатурой (возможно оптимально, но тут очень желательно цветовое выделение)