### PR TITLE
Убрал unsigned c norm_item.amount

### DIFF
--- a/Workwear.Sql/Scripts/2.8.15.sql
+++ b/Workwear.Sql/Scripts/2.8.15.sql
@@ -1,0 +1,3 @@
+# Убрал unsigned
+alter table norms_item
+	modify amount int default 1 not null;

--- a/Workwear.Sql/Scripts/new_empty.sql
+++ b/Workwear.Sql/Scripts/new_empty.sql
@@ -728,7 +728,7 @@ CREATE TABLE IF NOT EXISTS `norms_item` (
   `id` INT UNSIGNED NOT NULL AUTO_INCREMENT,
   `norm_id` INT UNSIGNED NOT NULL,
   `protection_tools_id` INT UNSIGNED NOT NULL,
-  `amount` INT UNSIGNED NOT NULL DEFAULT 1,
+  `amount` INT NOT NULL DEFAULT 1,
   `period_type` ENUM('Year', 'Month', 'Shift', 'Wearout', 'Duty') NOT NULL DEFAULT 'Year',
   `period_count` TINYINT UNSIGNED NOT NULL DEFAULT 1,
   `condition_id` INT UNSIGNED NULL DEFAULT NULL,


### PR DESCRIPTION
В доменной модели всё равно поле int
А вот в строке ведомости uint. Пока не стал менять, возможно есть смысл.
Хотя как будто кто-то когда-то давно скопипастил с поля id
Или было, чтобы можно было хранить число побольше в smallint. А я когда менял не стал unsigned убирать.