### PR TITLE
Проверка уже занятых ячеек при сохранении документа постомата.

### DIFF
--- a/Workwear/ViewModels/Postomats/PostomatDocumentViewModel.cs
+++ b/Workwear/ViewModels/Postomats/PostomatDocumentViewModel.cs
@@ -58,7 +58,9 @@ namespace Workwear.ViewModels.Postomats {
 						item.Location = new CellLocation(cell.CellTitle, cell.Location);
 				}
 			}
-			
+			Validations.Clear();
+			Validations.Add(new ValidationRequest(Entity, 
+				new ValidationContext(Entity, new Dictionary<object, object> {{nameof(IUnitOfWorkFactory), unitOfWorkFactory} })));
 			Entity.Items.CollectionChanged += (sender, args) => OnPropertyChanged(nameof(CanChangePostomat));
 		}
 


### PR DESCRIPTION
Возможно стоило добавить проверку, что эти заявки не добавлены в другие документы, но пока таких ситуаций не было